### PR TITLE
Add default value to field in node params

### DIFF
--- a/backends/zookeeper/zookeeper.go
+++ b/backends/zookeeper/zookeeper.go
@@ -75,7 +75,8 @@ func (b *backend) Spec() *operator.Spec {
 					Spec: &schema.Record{
 						Fields: map[string]*schema.Field{
 							"tickTime": {
-								Type: schema.TypeString,
+								Type:    schema.TypeString,
+								Default: "2000",
 							},
 						},
 					},

--- a/backends/zookeeper/zookeeper_test.go
+++ b/backends/zookeeper/zookeeper_test.go
@@ -21,7 +21,7 @@ func TestBootstrap(t *testing.T) {
 					Count: 3,
 					Params: schema.MapToSpec(
 						map[string]interface{}{
-							"tickTime": "2000",
+							// "tickTime": "2000",
 						},
 					),
 					Resources: schema.MapToSpec(

--- a/schema/resource_data.go
+++ b/schema/resource_data.go
@@ -7,10 +7,19 @@ import (
 )
 
 func NewResourceData(sch *Schema2, data *proto.Spec) *ResourceData {
-	return &ResourceData{
+	r := &ResourceData{
 		sch:     sch,
 		flatmap: flatten(data),
 	}
+	// fill in default values
+	for k, f := range sch.Spec.Fields {
+		if f.Default != "" {
+			if _, ok := r.flatmap[k]; !ok {
+				r.flatmap[k] = f.Default
+			}
+		}
+	}
+	return r
 }
 
 type ResourceData struct {

--- a/schema/types.go
+++ b/schema/types.go
@@ -70,6 +70,9 @@ type Field struct {
 
 	// ForceNew describes whether a change in the field requires delete the old one
 	ForceNew bool
+
+	// Default value for the field
+	Default string
 }
 
 // Type implements the Type interface


### PR DESCRIPTION
Add default value to a field in the schema. It uses that value to fill empty values in the node config params. 