### PR TITLE
Load instance from state by id

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -121,7 +121,7 @@ func (p *Provider) Setup(cplane operator.ControlPlane) error {
 			if msg == nil {
 				return
 			}
-			instance, err := cplane.GetInstance(msg.Id, msg.Cluster)
+			instance, err := cplane.GetInstance(msg.InstanceID)
 			if err != nil {
 				p.logger.Error("failed to get instance", "err", err)
 				continue
@@ -139,7 +139,7 @@ func (p *Provider) Setup(cplane operator.ControlPlane) error {
 }
 
 func (p *Provider) handlePodUpdate(deploymentID string, pod *PodItem) error {
-	instance, err := p.cplane.GetInstance(pod.Metadata.Name, deploymentID)
+	instance, err := p.cplane.GetInstance(pod.Metadata.Name)
 	if err != nil {
 		return err
 	}

--- a/operator/backend.go
+++ b/operator/backend.go
@@ -161,7 +161,7 @@ func (b *BaseOperator) Setup(cplane ControlPlane) {
 }
 
 func (b *BaseOperator) handleMsg(msg *InstanceUpdate) error {
-	instance, err := b.cplane.GetInstance(msg.Id, msg.Cluster)
+	instance, err := b.cplane.GetInstance(msg.InstanceID)
 	if err != nil {
 		return err
 	}

--- a/operator/control_plane.go
+++ b/operator/control_plane.go
@@ -7,13 +7,12 @@ import (
 )
 
 type InstanceUpdate struct {
-	Id      string
-	Cluster string
+	InstanceID string
 }
 
 type ControlPlane interface {
 	UpsertInstance(*proto.Instance) error
-	GetInstance(id, cluster string) (*proto.Instance, error)
+	GetInstance(instanceID string) (*proto.Instance, error)
 	SubscribeInstanceUpdates() <-chan *InstanceUpdate
 }
 
@@ -32,8 +31,7 @@ func (i *InmemControlPlane) UpsertInstance(ii *proto.Instance) error {
 	}
 	i.instances[ii.ID] = ii
 	update := &InstanceUpdate{
-		Id:      ii.ID,
-		Cluster: ii.DeploymentID,
+		InstanceID: ii.ID,
 	}
 	for _, ch := range i.subs {
 		select {
@@ -44,8 +42,8 @@ func (i *InmemControlPlane) UpsertInstance(ii *proto.Instance) error {
 	return nil
 }
 
-func (i *InmemControlPlane) GetInstance(id, cluster string) (*proto.Instance, error) {
-	ii, ok := i.instances[id]
+func (i *InmemControlPlane) GetInstance(InstanceID string) (*proto.Instance, error) {
+	ii, ok := i.instances[InstanceID]
 	if !ok {
 		return nil, nil
 	}

--- a/operator/server.go
+++ b/operator/server.go
@@ -126,7 +126,7 @@ func (s *Server) instanceWatcher() {
 }
 
 func (s *Server) handleInstanceUpdate(msg *InstanceUpdate) error {
-	instance, err := s.GetInstance(msg.Id, msg.Cluster)
+	instance, err := s.GetInstance(msg.InstanceID)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (s *Server) handleInstanceUpdate(msg *InstanceUpdate) error {
 			Id:           uuid.UUID(),
 			Status:       proto.Evaluation_PENDING,
 			TriggeredBy:  proto.Evaluation_NODECHANGE,
-			DeploymentID: msg.Cluster, // this is the deployment id
+			DeploymentID: instance.DeploymentID,
 			Type:         proto.EvaluationTypeCluster,
 		}
 		s.evalQueue.add(eval)
@@ -437,8 +437,7 @@ func (s *Server) UpsertInstance(n *proto.Instance) error {
 		return err
 	}
 	update := &InstanceUpdate{
-		Id:      n.ID,
-		Cluster: n.DeploymentID,
+		InstanceID: n.ID,
 	}
 
 	for _, ch := range s.subs {
@@ -450,8 +449,8 @@ func (s *Server) UpsertInstance(n *proto.Instance) error {
 	return nil
 }
 
-func (s *Server) GetInstance(id, cluster string) (*proto.Instance, error) {
-	return s.State.LoadInstance(cluster, id)
+func (s *Server) GetInstance(instanceID string) (*proto.Instance, error) {
+	return s.State.LoadNode(instanceID)
 }
 
 func (s *Server) SubscribeInstanceUpdates() <-chan *InstanceUpdate {

--- a/operator/state/boltdb/boltdb_test.go
+++ b/operator/state/boltdb/boltdb_test.go
@@ -478,3 +478,27 @@ func TestDependsOn_ComponentDoesNotExists(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+func TestDeployment_UpsertInstance(t *testing.T) {
+	db := testBoltdb(t)
+
+	dep := &proto.Deployment{
+		Id: "dep1",
+	}
+	assert.NoError(t, db.UpdateDeployment(dep))
+
+	i0 := &proto.Instance{
+		ID:           "i0",
+		DeploymentID: "dep1",
+	}
+	assert.NoError(t, db.UpsertNode(i0))
+
+	i0Res, err := db.LoadNode("i0")
+	assert.NoError(t, err)
+	assert.Equal(t, i0Res.ID, i0.ID)
+
+	depRes, err := db.LoadDeployment("dep1")
+	assert.NoError(t, err)
+	assert.Len(t, depRes.Instances, 1)
+	assert.Equal(t, depRes.Instances[0].ID, "i0")
+}

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -149,7 +149,7 @@ func (c *Client) runProvider() {
 }
 
 func (c *Client) handleInstanceMsg(msg *operator.InstanceUpdate) {
-	instance, err := c.controlPlane.GetInstance(msg.Id, msg.Cluster)
+	instance, err := c.controlPlane.GetInstance(msg.InstanceID)
 	if err != nil {
 		panic(err)
 	}
@@ -421,7 +421,7 @@ func (c *Client) createImpl(ctx context.Context, node *proto.Instance) (string, 
 
 		// panic("bad")
 
-		ii, err := c.controlPlane.GetInstance(node.ID, node.DeploymentID)
+		ii, err := c.controlPlane.GetInstance(node.ID)
 		if err != nil {
 			panic(err)
 		}

--- a/testutil/testing.go
+++ b/testutil/testing.go
@@ -43,7 +43,7 @@ func readEvent(p operator.ControlPlane, t *testing.T) *proto.Instance {
 
 	select {
 	case msg := <-ch:
-		instance, err := p.GetInstance(msg.Id, msg.Cluster)
+		instance, err := p.GetInstance(msg.InstanceID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -76,7 +76,7 @@ func waitForEvent(c operator.ControlPlane, t *testing.T, handler func(i *proto.I
 	for {
 		select {
 		case evnt := <-evnts:
-			instance, err := c.GetInstance(evnt.Id, evnt.Cluster)
+			instance, err := c.GetInstance(evnt.InstanceID)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Before, the operator would need both the deployment id and the instance id to get the reference of the instance. Then, there was always the need to keep both values together available at the same time on the different async ops (i.e. Provider). Now, it only needs the id to get the reference of the instance.